### PR TITLE
add `Pending` case to `ContractStatus`

### DIFF
--- a/examples/http_symbols.rs
+++ b/examples/http_symbols.rs
@@ -1,0 +1,16 @@
+use bybit::{http, rest::*, Result};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    println!("printing all symbols");
+
+    // safe to unwrap because we know url is valid
+    let client = http::Client::new(http::MAINNET_BYBIT, "", "").unwrap();
+    let symbols = client.fetch_symbols().await?;
+
+    for symbol in symbols.symbols() {
+        println!("{:?}", symbol);
+    }
+
+    Ok(())
+}

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -12,6 +12,8 @@ pub enum ContractStatus {
     Trading,
     Settling,
     Closed,
+    // The `Pending` status doesn't appear anywhere in the API docs, however it has been spotted in the wild.
+    Pending,
 }
 
 impl Default for ContractStatus {


### PR DESCRIPTION
Although the API docs do not make any mention of a Pending contract status, it has been spotted in the wild.
This PR adds the `Pending` case to `ContractStatus` to make sure users of this library do not run into random crashes.